### PR TITLE
tests and engines field for (u)int64

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,6 +129,8 @@ function arrayView (type, offset, size) {
 
 function typeSize (a) {
   switch (a) {
+    case 'BigInt64Array':
+    case 'BigUint64Array':
     case 'Float64Array':
     return 8
 
@@ -171,6 +173,12 @@ function arrayType (type) {
     case 'uint32_t':
     return 'Uint32Array'
 
+    case 'uint64_t':
+    return 'BigUint64Array'
+
+    case 'int64_t':
+    return 'BigInt64Array'
+    
     case 'uint16_t':
     return 'Uint16Array'
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/mafintosh/shared-structs.git"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "author": "Mathias Buus (@mafintosh)",
   "license": "MIT",
   "bugs": {

--- a/parse.js
+++ b/parse.js
@@ -263,7 +263,7 @@ function times (a, b) {
 }
 
 function validId (n) {
-  return /^[a-z_]([a-z0-9_])*$/i.test(n)
+  return /^[a-z_]([a-z0-9_.])*$/i.test(n)
 }
 
 function evalNumber (expr) {

--- a/test/compile.js
+++ b/test/compile.js
@@ -37,6 +37,8 @@ tape('complex', function (t) {
       bar c[10];
       bar d[1][2][3];
       int e;
+      int64_t i64;
+      uint64_t u64;
     };
   `)
 
@@ -57,8 +59,14 @@ tape('complex', function (t) {
   foo.d[0][1][1].buf[100] = 11
   t.same(foo.d[0][1][1].buf[100], 11)
 
-  t.same(foo.rawBuffer.length, 32992)
-  t.notSame(foo.rawBuffer, Buffer.alloc(32992))
+  foo.i64 = -755n;
+  t.same(foo.i64, -755n);
+
+  foo.u64 = 777n;
+  t.same(foo.u64, 777n);
+
+  t.same(foo.rawBuffer.length, 33008)
+  t.notSame(foo.rawBuffer, Buffer.alloc(33008))
 
   const fooClone = structs.foo(foo.rawBuffer)
 
@@ -67,7 +75,9 @@ tape('complex', function (t) {
   t.same(fooClone.b[0][10], 0.1)
   t.same(fooClone.c[0].buf[42], 10)
   t.same(fooClone.d[0][1][1].buf[100], 11)
-  t.same(fooClone.rawBuffer.length, 32992)
+  t.same(fooClone.i64, -755n);
+  t.same(fooClone.u64, 777n);
+  t.same(fooClone.rawBuffer.length, 33008)
 
   t.ok(fooClone.rawBuffer === foo.rawBuffer)
 


### PR DESCRIPTION
Just a quick test for uint64 and int64. Also adding the engines field because BigInts are only supported (for Buffer access) on Node >=12.

This is currently based on #5. Happy to rebase once that's merged.