### PR TITLE
Corrected bug for buffer views and added test case for loading buffer views

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function arrayView (type, offset, size) {
     return 'this.rawBuffer.slice(offset + ' + offset + ', offset + ' + (offset + size) + ')'
   }
   if (!offset) return 'new ' + a + '(this.rawArrayBuffer, this.rawBuffer.byteOffset + offset, ' + (size / typeSize(a)) + ')'
-  return 'new ' + a + '(this.rawArrayBuffer, this.rawBuffer.byteOffset + ' + offset + ', ' + (size / typeSize(a)) + ')'
+  return 'new ' + a + '(this.rawArrayBuffer, this.rawBuffer.byteOffset + offset + ' + offset + ', ' + (size / typeSize(a)) + ')'
 }
 
 function typeSize (a) {

--- a/index.js
+++ b/index.js
@@ -123,8 +123,8 @@ function arrayView (type, offset, size) {
     if (!offset) return 'this.rawBuffer.slice(offset, offset + ' + size + ')'
     return 'this.rawBuffer.slice(offset + ' + offset + ', offset + ' + (offset + size) + ')'
   }
-  if (!offset) return 'new ' + a + '(this.rawArrayBuffer, offset, ' + (size / typeSize(a)) + ')'
-  return 'new ' + a + '(this.rawArrayBuffer, offset + ' + offset + ', ' + (size / typeSize(a)) + ')'
+  if (!offset) return 'new ' + a + '(this.rawArrayBuffer, this.rawBuffer.byteOffset + offset, ' + (size / typeSize(a)) + ')'
+  return 'new ' + a + '(this.rawArrayBuffer, this.rawBuffer.byteOffset + ' + offset + ', ' + (size / typeSize(a)) + ')'
 }
 
 function typeSize (a) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "generate-function": "^2.0.0"
   },
   "devDependencies": {
-    "tape": "^4.9.1"
+    "tape": "^4.9.1",
+    "temp": "^0.9.4"
   },
   "scripts": {
     "test": "tape test/*.js"

--- a/test/compile.js
+++ b/test/compile.js
@@ -83,3 +83,40 @@ tape('complex', function (t) {
 
   t.end()
 })
+
+
+tape('view parse', function (t) {
+	const structs = compile(`
+		struct foo {
+		uint32_t magic1;
+		uint32_t magic2;
+		uint32_t magic3;
+		uint32_t magic4;
+		uint32_t magic5;
+		};
+	`)
+
+	let struct1=structs.foo();
+	struct1.magic1=1;
+	struct1.magic2=2;
+	struct1.magic3=3;
+	struct1.magic4=4;
+	struct1.magic5=5;
+
+	const fs=require('fs');
+
+	var temp = require("temp").track();
+	var tempName = temp.path({suffix: '.pdf'});
+
+	fs.writeFileSync(tempName,struct1.rawBuffer, { encoding: 'buffer' });
+
+	let struct2=structs.foo(fs.readFileSync(tempName));
+
+	t.same(struct1.magic1, struct2.magic1);
+	t.same(struct1.magic2, struct2.magic2);
+	t.same(struct1.magic3, struct2.magic3);
+	t.same(struct1.magic4, struct2.magic4);
+	t.same(struct1.magic5, struct2.magic5);
+
+  	t.end();
+})


### PR DESCRIPTION
Corrected bug for buffer views. See #issue-833030083 https://github.com/mafintosh/shared-structs/issues/8

Unit tests before fix:
````
> shared-structs@1.4.0 test
> tape test/*.js

TAP version 13
1..31
# tests 31
# pass  26
# fail  5
````
Units tests after:
````
> shared-structs@1.4.0 test
> tape test/*.js

TAP version 13
1..31
# tests 31
# pass  31

# ok
````

