### PR TITLE
Properly handle signed byte fields and use typed array for both signed/unsigned byte fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,10 @@ function typeSize (a) {
     case 'Uint16Array':
     case 'Int16Array':
     return 2
+
+    case 'Uint8Array':
+    case 'Int8Array':
+    return 1
   }
 
   return 0
@@ -162,9 +166,11 @@ function arrayType (type) {
     case 'uint8_t':
     case 'bool':
     case 'byte':
-    case 'int8_t':
     case 'char':
-    return 'Buffer'
+    return 'Uint8Array'
+
+    case 'int8_t':
+    return 'Int8Array'
 
     case 'int16_t':
     return 'Int16Array'

--- a/test/compile.js
+++ b/test/compile.js
@@ -117,3 +117,20 @@ tape('view parse', function (t) {
 
   t.end()
 })
+
+tape("signed_bytes", function (t) {
+  const structs = compile(`
+  struct foo {
+    uint8_t ub;
+    int8_t ib;
+  };`);
+
+  const foo = structs.foo();
+
+  foo.ub = 200;
+  foo.ib = -100;
+
+  t.same(foo.ub, 200);
+  t.same(foo.ib, -100);
+  t.end();
+});


### PR DESCRIPTION
As per-subject: this patch allow proper handling of int8_t fields.
Also, for consistency, use Uint8Array instead of buffer for the unsigned byte-sized fields.